### PR TITLE
added check for errors from headless

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -25,9 +25,9 @@ argue.firefox = function (br, uri, opts, cb) {
             ,
         ].map(function (x) { return 'user_pref(' + x + ');\n' }).join('');
     }
-    
+
     prefs += 'user_pref("browser.shell.checkDefaultBrowser", false);\n';
-    
+
     var file = path.join(path.dirname(br.profile.file), 'user.js');
     fs.writeFile(file, prefs, function (err) {
         if (err) cb(err)
@@ -71,17 +71,17 @@ argue.phantom = function (br, uri, opts, cb) {
     var src = '(new WebPage).open('
         + JSON.stringify(uri)
         + ',function(){})'
-    ;   
+    ;
     fs.writeFile(file, src, function (err) {
         if (err) cb(err)
         else cb(null, opts.options.concat([
             opts.proxy ?
-                '--proxy=' + opts.proxy.replace(/^http:\/\//, '') 
+                '--proxy=' + opts.proxy.replace(/^http:\/\//, '')
                 : null
-            ,   
+            ,
             file
         ]).filter(Boolean))
-    }); 
+    });
 };
 
 module.exports = function (config, name, version) {
@@ -90,11 +90,16 @@ module.exports = function (config, name, version) {
     return function (uri, opts, cb) {
         if (opts.headless && !m.headless) {
             headless(function (err, proc, display) {
-                run({ DISPLAY : ':' + display }); 
-            }); 
-        }   
+                if (err) {
+                    cb(new Error('Attempted to launch ' + name + ' headlessly, ' +
+                        'but received error "' + err.message + '"'));
+                } else {
+                    run({ DISPLAY : ':' + display });
+                }
+            });
+        }
         else run({})
-    
+
         function run (env_) {
             var env = {},
                 cwd = process.cwd();
@@ -105,7 +110,7 @@ module.exports = function (config, name, version) {
             Object.keys(env_).forEach(function (key) {
                 env[key] = env_[key];
             });
-            
+
             argue[m.type](m, uri, opts, function (err, args) {
                 if (err) return cb(err);
                 if (opts.noProxy && env.no_proxy === undefined) {
@@ -140,7 +145,7 @@ module.exports = function (config, name, version) {
                         break;
                 }
                 cb(null, spawn(m.command, args, { env : env, cwd: cwd }));
-                
+
             });
         }
     };
@@ -166,7 +171,7 @@ function selectMatch (config, name, version) {
 
 function matches (version, pattern) {
     if (pattern === undefined || pattern === '*') return true;
-    
+
     // todo: real semvers
     var vs = version.split('.');
     var ps = pattern.split('.');


### PR DESCRIPTION
headless currently does not catch errors, or send callbacks errors, but if kesla/node-headless#10 get's merged, or any other check for it's major dependency is put into place, this error arg might be useful for OSX users who have not installed Xvfb.
