### PR TITLE
Drop PhantomJS support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,7 @@
 Detect the browser versions available on your system and launch them in an
 isolated profile for automated testing purposes.
 
-You can launch browsers headlessly (if you have Xvfb or with phantom) and set
+You can launch browsers headlessly (if you have Xvfb) and set
 the proxy configuration on the fly.
 
 # example
@@ -45,13 +45,6 @@ $ node example/launch.js
        profile: '/home/substack/.config/browser-launcher/chromium-18.0.1025.168_e025d855',
        command: 'chromium-browser',
        version: '18.0.1025.168' },
-     { name: 'phantom',
-       re: {},
-       type: 'phantom',
-       headless: true,
-       profile: '/home/substack/.config/browser-launcher/phantom-1.4.0_31767fa2',
-       command: 'phantomjs',
-       version: '1.4.0' },
      { name: 'firefox',
        re: {},
        type: 'firefox',
@@ -78,7 +71,7 @@ Launch a new instance of `opts.browser` with the optional version constraint
 `opts.version`. Without an `opts.version`, the highest version of `opts.browser`
 is used.
 
-To launch the browser headlessly (if it isn't already headless like phantom),
+To launch the browser headlessly (if it isn't already headless),
 set `opts.headless`. This launches the browser with
 [node-headless](https://github.com/kesla/node-headless/)
 which uses the `Xvfb` command to create a fake X server.

--- a/lib/detect.js
+++ b/lib/detect.js
@@ -21,13 +21,6 @@ var browsers = {
         type : 'firefox',
         profile : true,
     },
-    'phantomjs' : {
-        name : 'phantom',
-        re : /(\S+)/,
-        type : 'phantom',
-        headless : true,
-        profile : true,
-    },
     'safari': {
     	name: 'safari',
         type: 'safari',

--- a/lib/run.js
+++ b/lib/run.js
@@ -64,26 +64,6 @@ argue.chrome = function (br, uri, opts, cb) {
     ]).filter(Boolean));
 };
 
-argue.phantom = function (br, uri, opts, cb) {
-    // `phantomjs uri` would be TOO EASY I guess?
-    opts.options = opts.options || [];
-    var file = path.join(br.profile, 'phantom.js');
-    var src = '(new WebPage).open('
-        + JSON.stringify(uri)
-        + ',function(){})'
-    ;   
-    fs.writeFile(file, src, function (err) {
-        if (err) cb(err)
-        else cb(null, opts.options.concat([
-            opts.proxy ?
-                '--proxy=' + opts.proxy.replace(/^http:\/\//, '') 
-                : null
-            ,   
-            file
-        ]).filter(Boolean))
-    }); 
-};
-
 module.exports = function (config, name, version) {
     var m = selectMatch(config, name, version);
     if (!m) return;
@@ -123,7 +103,7 @@ module.exports = function (config, name, version) {
                         cwd = require('path').dirname(m.command); //Change directory to the app's base (Chrome)
                         break;
                     case 'darwin':
-                        if (m.name !== 'firefox' && m.name !== 'phantom') { //Use the bin path under the hood
+                        if (m.name !== 'firefox') { //Use the bin path under the hood
                             /*
                             This creates a command line structure like this:
                             open --wait-apps --new --fresh -a /Path/To/Executable <url> --args <rest of app args>

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "keywords": [
     "browser",
     "headless",
-    "phantom",
     "chrome",
     "firefox",
     "chromium",


### PR DESCRIPTION
Closes #44 

PhantomJS was [discontinued in March 2018](https://github.com/ariya/phantomjs/issues/15344); the last release was in 2016.

When merged, this will be released as a breaking.